### PR TITLE
[Swift] Fix class spelling

### DIFF
--- a/Swift/ParallelChange/ParallelChangeTest/AuthenticationService.swift
+++ b/Swift/ParallelChange/ParallelChangeTest/AuthenticationService.swift
@@ -25,7 +25,7 @@ class AuthenticationClient {
     }
 }
 
-class JetAnotherClient {
+class YetAnotherClient {
     func run() {
         AuthenticationService().isAuthenticated(100)
     }


### PR DESCRIPTION
As seen in this commit: https://github.com/waterlink/parallel-change/commit/c813ecad3a243a80f7ebdafa0c2ed625c163f118