### PR TITLE
Csharp: update deprecated dotnet version to 4.8

### DIFF
--- a/Csharp/ParallelAndNarrowChange/ParallelAndNarrowChange.csproj
+++ b/Csharp/ParallelAndNarrowChange/ParallelAndNarrowChange.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ParallelAndNarrowChange</RootNamespace>
     <AssemblyName>ParallelAndNarrowChange</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Csharp/ParallelAndNarrowChange/packages.config
+++ b/Csharp/ParallelAndNarrowChange/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.2.2" targetFramework="net45" />
-  <package id="NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net45" />
-  <package id="NUnitTestAdapter.WithFramework" version="2.0.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.2.2" targetFramework="net48" />
+  <package id="NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net48" />
+  <package id="NUnitTestAdapter.WithFramework" version="2.0.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Dotnet Framework 4.5 will reach end of support next year and is already deprecated ([Dotnet Blog](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/)).
I updated the files to build and work against Dotnet Framework 4.8 which is still supported.